### PR TITLE
🔧 fix: 작가 리스트 반환 시 응답 필드 간략화

### DIFF
--- a/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
@@ -9,6 +9,7 @@ import snap.api.photographer.dto.request.PhotographerCustomDto;
 import snap.api.photographer.dto.response.PhotographerNameResponseDto;
 import snap.api.photographer.dto.response.PhotographerResponseDto;
 import snap.api.photographer.dto.response.PhotographerSearchResponseDto;
+import snap.api.photographer.dto.response.PhotographerSimpleDto;
 import snap.api.photographer.service.PhotographerService;
 import snap.domains.photographer.entity.Photographer;
 import snap.dto.request.PhotographerFilterReq;
@@ -45,12 +46,12 @@ public class PhotographerController {
     }
 
     @GetMapping("/tag")
-    public ResponseEntity<List<PhotographerResponseDto>> photographerFindByTag(@RequestParam String tag){
+    public ResponseEntity<List<PhotographerSimpleDto>> photographerFindByTag(@RequestParam String tag){
         return new ResponseEntity<>(photographerService.findByTag(tag), HttpStatus.OK);
     }
 
     @GetMapping
-    public ResponseEntity<List<PhotographerResponseDto>> photographerList(PhotographerFilterReq filterReq, Pageable pageable){
+    public ResponseEntity<List<PhotographerSimpleDto>> photographerList(PhotographerFilterReq filterReq, Pageable pageable){
         return new ResponseEntity<>(photographerService.findByFilter(filterReq, pageable), HttpStatus.OK);
     }
 

--- a/snapspot-api/src/main/java/snap/api/photographer/dto/response/PhotographerSearchResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/dto/response/PhotographerSearchResponseDto.java
@@ -9,12 +9,12 @@ import java.util.List;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class PhotographerSearchResponseDto {
-    private List<PhotographerResponseDto> nicknameResult;
-    private List<PhotographerResponseDto> areaResult;
+    private List<PhotographerSimpleDto> nicknameResult;
+    private List<PhotographerSimpleDto> areaResult;
 
     public PhotographerSearchResponseDto(
-            List<PhotographerResponseDto> nicknameResult,
-            List<PhotographerResponseDto> areaResult) {
+            List<PhotographerSimpleDto> nicknameResult,
+            List<PhotographerSimpleDto> areaResult) {
         this.nicknameResult = nicknameResult;
         this.areaResult = areaResult;
     }

--- a/snapspot-api/src/main/java/snap/api/photographer/dto/response/PhotographerSimpleDto.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/dto/response/PhotographerSimpleDto.java
@@ -1,0 +1,43 @@
+package snap.api.photographer.dto.response;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import snap.api.spot.dto.AreaResponseDto;
+import snap.domains.photographer.entity.Photographer;
+import snap.domains.photographer.entity.PhotographerArea;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class PhotographerSimpleDto {
+
+    private Long photographerId;
+    private String nickname;
+    private Long lowestPay;
+    private String image;
+    private List<AreaResponseDto> areas;
+    private SpecialListDto specialList;
+    private TagsDto tags;
+
+    /**
+     * TODO: review 브랜치 머지 후 별점, 리뷰 수 필드 추가
+     *
+     */
+
+    @Builder
+    public PhotographerSimpleDto(Photographer entity) {
+        this.photographerId = entity.getPhotographerId();
+        this.nickname = entity.getMember().getNickname();
+        this.lowestPay = entity.getLowestPay();
+        this.image = entity.getImages().getImage1();
+        this.areas = entity.getAreas().stream().map(PhotographerArea::getArea)
+                .map(AreaResponseDto::new)
+                .collect(Collectors.toList());
+        this.specialList = new SpecialListDto(entity.getSpecialList());
+        this.tags = new TagsDto(entity.getTags());
+    }
+}

--- a/snapspot-api/src/main/java/snap/api/photographer/service/PhotographerService.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/service/PhotographerService.java
@@ -8,6 +8,7 @@ import snap.api.photographer.dto.request.PhotographerCustomDto;
 import snap.api.photographer.dto.response.PhotographerNameResponseDto;
 import snap.api.photographer.dto.response.PhotographerResponseDto;
 import snap.api.photographer.dto.response.PhotographerSearchResponseDto;
+import snap.api.photographer.dto.response.PhotographerSimpleDto;
 import snap.domains.photographer.entity.Photographer;
 import snap.domains.photographer.service.*;
 import snap.dto.request.PhotographerFilterReq;
@@ -35,23 +36,23 @@ public class PhotographerService {
     }
 
     public PhotographerSearchResponseDto findBySearch(String word) {
-        List<PhotographerResponseDto> nicknameResult =
+        List<PhotographerSimpleDto> nicknameResult =
                 photographerDomainService.findByNickname(word).stream()
-                        .map(PhotographerResponseDto::new)
+                        .map(PhotographerSimpleDto::new)
                         .collect(Collectors.toList());
 
-        List<PhotographerResponseDto> areaResult =
+        List<PhotographerSimpleDto> areaResult =
                 photographerAreaDomainService.findPhotographerListByArea(word).stream()
-                        .map(PhotographerResponseDto::new)
+                        .map(PhotographerSimpleDto::new)
                         .collect(Collectors.toList());
 
         return new PhotographerSearchResponseDto(nicknameResult, areaResult);
     }
 
-    public List<PhotographerResponseDto> findByTag(String tag){
+    public List<PhotographerSimpleDto> findByTag(String tag){
         List<Photographer> photographerList = photographerTagDomainService.findPhotographerListByTag(tag);
         return photographerList.stream()
-                .map(PhotographerResponseDto::new)
+                .map(PhotographerSimpleDto::new)
                 .collect(Collectors.toList());
     }
 
@@ -66,9 +67,9 @@ public class PhotographerService {
                 .getContent();
     }
 
-    public List<PhotographerResponseDto> findByFilter(PhotographerFilterReq filterReq, Pageable pageable){
+    public List<PhotographerSimpleDto> findByFilter(PhotographerFilterReq filterReq, Pageable pageable){
         return photographerDomainService.findAllByFilter(filterReq, pageable)
-                .map(PhotographerResponseDto::new)
+                .map(PhotographerSimpleDto::new)
                 .getContent();
     }
 


### PR DESCRIPTION
작가 리스트를 반환하는
- 작가 검색 api
- 작가 목록 조회 api
- 태그로 작가 검색 api

를 수정하였습니다.

이 PR을 머지한 후에, heart 브랜치에서 `좋아요 모아보기 기능`에도 응답 필드 간략화 적용하겠습니다.