### PR TITLE
✨ feat: 고객/작가의 계정 정보 수정 기능

### DIFF
--- a/snapspot-admin/src/main/java/snap/service/PasswordService.java
+++ b/snapspot-admin/src/main/java/snap/service/PasswordService.java
@@ -1,0 +1,16 @@
+package snap.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import snap.domains.member.entity.Member;
+
+@Service
+@RequiredArgsConstructor
+public class PasswordService {
+    private final PasswordEncoder passwordEncoder;
+
+    public Boolean verifyPassword(Member member, String password) {
+        return passwordEncoder.matches(password, member.getPassword());
+    }
+}

--- a/snapspot-api/src/main/java/snap/api/member/MemberController.java
+++ b/snapspot-api/src/main/java/snap/api/member/MemberController.java
@@ -5,6 +5,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import snap.api.member.dto.LoginRequestDto;
+import snap.api.member.dto.MemberModifyRequestDto;
 import snap.api.member.dto.MemberResponseDto;
 import snap.api.member.dto.SignupRequestDto;
 import snap.domains.member.entity.Member;
@@ -15,8 +16,15 @@ import snap.resolver.AuthMember;
 @RequestMapping("/members")
 public class MemberController {
 
+    private final MemberService memberService;
+
     @GetMapping("/me")
     public ResponseEntity<MemberResponseDto> memberInfoFind(@AuthMember Member member) {
         return new ResponseEntity<>(new MemberResponseDto(member), HttpStatus.OK);
+    }
+
+    @PutMapping("/setting")
+    public ResponseEntity<MemberResponseDto> memberUpdate(@AuthMember Member member, @RequestBody MemberModifyRequestDto requestDto){
+        return new ResponseEntity<>(memberService.updateMember(member, requestDto), HttpStatus.OK);
     }
 }

--- a/snapspot-api/src/main/java/snap/api/member/MemberService.java
+++ b/snapspot-api/src/main/java/snap/api/member/MemberService.java
@@ -3,7 +3,11 @@ package snap.api.member;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import snap.api.member.dto.MemberModifyRequestDto;
+import snap.api.member.dto.MemberResponseDto;
+import snap.domains.member.entity.Member;
 import snap.domains.member.service.MemberDomainService;
+import snap.service.PasswordService;
 
 import javax.persistence.EntityNotFoundException;
 
@@ -12,5 +16,14 @@ import javax.persistence.EntityNotFoundException;
 @RequiredArgsConstructor
 public class MemberService{
     private final MemberDomainService memberDomainService;
+    private final PasswordService passwordService;
 
+    public MemberResponseDto updateMember(Member member, MemberModifyRequestDto requestDto) {
+        if (passwordService.verifyPassword(member, requestDto.getPassword())) {
+            return new MemberResponseDto(memberDomainService.updateMember(member,
+                    requestDto.getNickname(), requestDto.getProfileImage(), requestDto.getEmail()));
+        }
+        else
+            throw new RuntimeException("비밀번호가 맞지 않습니다.");
+    }
 }

--- a/snapspot-api/src/main/java/snap/api/member/dto/MemberModifyRequestDto.java
+++ b/snapspot-api/src/main/java/snap/api/member/dto/MemberModifyRequestDto.java
@@ -1,0 +1,14 @@
+package snap.api.member.dto;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MemberModifyRequestDto {
+    private String nickname;
+    private String profileImage;
+    private String email;
+    private String password;
+}

--- a/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
@@ -5,6 +5,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import snap.api.member.MemberService;
+import snap.api.member.dto.MemberModifyRequestDto;
+import snap.api.member.dto.MemberResponseDto;
 import snap.api.photographer.dto.request.PhotographerCustomDto;
 import snap.api.photographer.dto.response.PhotographerNameResponseDto;
 import snap.api.photographer.dto.response.PhotographerResponseDto;
@@ -26,6 +29,7 @@ import java.util.List;
 public class PhotographerController {
 
     private final PhotographerService photographerService;
+    private final MemberService memberService;
 
     @GetMapping("/me")
     public ResponseEntity<PhotographerResponseDto> photographerInfoFind(@AuthPhotographer Photographer photographer) {
@@ -61,5 +65,10 @@ public class PhotographerController {
     @GetMapping("/name")
     public ResponseEntity<List<PhotographerNameResponseDto>> photographerNameList(){
         return new ResponseEntity<>(photographerService.findAllNames(), HttpStatus.OK);
+    }
+
+    @PutMapping("/setting")
+    public ResponseEntity<MemberResponseDto> photographerUpdate(@AuthPhotographer Photographer photographer, @RequestBody MemberModifyRequestDto requestDto){
+        return new ResponseEntity<>(memberService.updateMember(photographer.getMember(), requestDto), HttpStatus.OK);
     }
 }

--- a/snapspot-domain/src/main/java/snap/domains/member/entity/Member.java
+++ b/snapspot-domain/src/main/java/snap/domains/member/entity/Member.java
@@ -53,4 +53,8 @@ public class Member {
         this.nickname = nickname;
         this.profileImage = profileImage;
     }
+
+    public void updateEmail(String email){
+        this.email = email;
+    }
 }

--- a/snapspot-domain/src/main/java/snap/domains/member/service/MemberDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/member/service/MemberDomainService.java
@@ -48,4 +48,10 @@ public class MemberDomainService {
                         .build()
         );
     }
+
+    public Member updateMember(Member member, String nickname, String profileImage, String email) {
+        member.updateMember(nickname, profileImage);
+        member.updateEmail(email);
+        return member;
+    }
 }


### PR DESCRIPTION
- 고객
<img width="581" alt="image" src="https://github.com/Snap-Spot/snapspot-api/assets/121334671/1ab50ee2-884a-4509-80ac-6b244176fdd5">

- 작가
<img width="580" alt="image" src="https://github.com/Snap-Spot/snapspot-api/assets/121334671/7bc8ec9f-6855-4b55-a017-1f57fd74305d">

  - 비밀번호 틀렸을 때
<img width="580" alt="image" src="https://github.com/Snap-Spot/snapspot-api/assets/121334671/65769333-87d6-457d-b254-c812ad9b817c">

## To Reviewers
이메일을 변경한 후, 사용자 정보가 필요한 api를 실행하면 자격증명이 되지 않았다는 에러가 발생합니다. 
변경한 이메일로 다시 로그인하면 잘 작동은 합니다만, 
저희 서비스에서 이메일은 아이디와 같이 사용자를 식별하는 데 쓰기 때문에, 변경할 수 없게 만들면 더 좋을 것 같습니다.
