### PR TITLE
✨ feat: 리뷰 기능 title 추가 및 별점 높은 순 정렬 구현

### DIFF
--- a/snapspot-api/src/main/java/snap/api/review/dto/PhotographerReviewResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/review/dto/PhotographerReviewResponseDto.java
@@ -3,10 +3,12 @@ package snap.api.review.dto;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.domain.Sort;
 import snap.api.photographer.dto.response.PhotographerResponseDto;
 import snap.domains.photographer.entity.Photographer;
 import snap.domains.review.entity.Review;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -22,6 +24,6 @@ public class PhotographerReviewResponseDto {
         this.photographer = new PhotographerResponseDto(photographer);
         this.totalReview = entities.size();
         this.averageScore = (entities.stream().mapToDouble(Review::getScore).sum() / entities.size());
-        this.reviews = entities.stream().map(ReviewResponseDto::new).toList();
+        this.reviews = entities.stream().map(ReviewResponseDto::new).sorted(Comparator.comparing(ReviewResponseDto::getScore).reversed()).collect(Collectors.toList());
     }
 }

--- a/snapspot-api/src/main/java/snap/api/review/dto/ReviewRequestDto.java
+++ b/snapspot-api/src/main/java/snap/api/review/dto/ReviewRequestDto.java
@@ -11,6 +11,7 @@ import java.util.UUID;
 public class ReviewRequestDto {
     private UUID planId;
     private Integer score;
+    private String title;
     private String comment;
     private String image;
 }

--- a/snapspot-api/src/main/java/snap/api/review/dto/ReviewResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/review/dto/ReviewResponseDto.java
@@ -13,6 +13,7 @@ public class ReviewResponseDto {
     private PlanResponseDto plan;
     private Integer score;
     private String image;
+    private String title;
     private String comment;
 
     public ReviewResponseDto(Review entity) {
@@ -20,6 +21,7 @@ public class ReviewResponseDto {
         this.plan = new PlanResponseDto(entity.getPlan());
         this.score = entity.getScore();
         this.image = entity.getImage();
+        this.title = entity.getTitle();
         this.comment = entity.getComment();
     }
 }

--- a/snapspot-api/src/main/java/snap/api/review/service/ReviewService.java
+++ b/snapspot-api/src/main/java/snap/api/review/service/ReviewService.java
@@ -27,7 +27,7 @@ public class ReviewService {
     public void createReview(Member member, ReviewRequestDto request) {
         Plan plan = planDomainService.findByPlanIdAndMember(request.getPlanId(), member);
         if (plan.getStatus().equals(Status.DELIVERY)) {
-            reviewDomainService.createReview(plan, request.getImage(), request.getScore(), request.getComment());
+            reviewDomainService.createReview(plan, request.getImage(), request.getScore(), request.getTitle(), request.getComment());
         } else {
             throw new IllegalArgumentException("사진 전달이 완료되지 않은 촬영입니다.");
         }

--- a/snapspot-domain/src/main/java/snap/domains/review/entity/Review.java
+++ b/snapspot-domain/src/main/java/snap/domains/review/entity/Review.java
@@ -23,15 +23,19 @@ public class Review {
     private Integer score;
 
     @Column
+    private String title;
+
+    @Column
     private String comment;
 
     @Column
     private String image;
 
     @Builder
-    public Review(Plan plan, Integer score, String comment, String image) {
+    public Review(Plan plan, Integer score, String title, String comment, String image) {
         this.plan = plan;
         this.score = score;
+        this.title = title;
         this.comment = comment;
         this.image = image;
     }

--- a/snapspot-domain/src/main/java/snap/domains/review/repository/ReviewRepository.java
+++ b/snapspot-domain/src/main/java/snap/domains/review/repository/ReviewRepository.java
@@ -9,5 +9,5 @@ import java.util.List;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {
     List<Review> findAllByPlan_Photographer(Photographer photographer);
-    List<Review> findAllByPlan_Customer(Member customer);
+    List<Review> findAllByPlan_CustomerOrderByScoreDesc(Member customer);
 }

--- a/snapspot-domain/src/main/java/snap/domains/review/service/ReviewDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/review/service/ReviewDomainService.java
@@ -17,9 +17,9 @@ import java.util.List;
 public class ReviewDomainService {
     private final ReviewRepository reviewRepository;
 
-    public void createReview(Plan plan, String image, Integer score, String comment) {
+    public void createReview(Plan plan, String image, Integer score, String title, String comment) {
         reviewRepository.save(
-                Review.builder().image(image).comment(comment).score(score).plan(plan)
+                Review.builder().image(image).title(title).comment(comment).score(score).plan(plan)
                 .build());
     }
 

--- a/snapspot-domain/src/main/java/snap/domains/review/service/ReviewDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/review/service/ReviewDomainService.java
@@ -1,6 +1,7 @@
 package snap.domains.review.service;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import snap.domains.member.entity.Member;
 import snap.domains.photographer.entity.Photographer;
@@ -28,6 +29,6 @@ public class ReviewDomainService {
     }
 
     public List<Review> findReviewListByMember(Member member) {
-        return reviewRepository.findAllByPlan_Customer(member);
+        return reviewRepository.findAllByPlan_CustomerOrderByScoreDesc(member);
     }
 }


### PR DESCRIPTION
# Details
## 리뷰 기능 title 추가
* 리뷰 엔티티 및 DB에 title 추가했습니다.
* 리뷰 작성 request dto와 리뷰 조회 response dto에 title 추가했습니다.
* 리뷰 조회 시 고객 id가 응답값으로 나오도록 되어 있길래 고객 이름은 반영하지 않았습니다. (필요 시 작업하겠습니다)
## 리뷰 별점 높은 순 정렬 구현
* 리뷰 조회 시 별점 높은 순으로 기본 정렬되도록 구현했습니다.
* 제 Java 버전에서는 .toList()가 지원되지 않아서 PhotographerReviewResponseDto.java에서 `.toList()` -> `.collect(Collectors.toList())`로 수정하여 작업했습니다. 

# Notice
* 기능 수정하며 변경된 부분 API 문서에 반영했습니다.
* 포스트맨 테스트 결과는 API 문서에서 확인해보시면 됩니다.