### PR TITLE
✨ feat: 회원가입 에러메세지

### DIFF
--- a/snapspot-domain/src/main/java/snap/domains/member/service/MemberDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/member/service/MemberDomainService.java
@@ -31,6 +31,9 @@ public class MemberDomainService {
     }
 
     public Member createMember(Member member) {
+        if (memberRepository.existsByEmail(member.getEmail())) {
+            throw new IllegalArgumentException("이미 가입된 이메일입니다.");
+        }
         return memberRepository.save(member);
     }
 


### PR DESCRIPTION
## Details
- 회원가입 시 이메일 중복인 경우 에러메세지 추가했습니다.
![이메일중복](https://github.com/Snap-Spot/snapspot-api/assets/97473239/3992cfaf-ea9d-49c2-910d-b792a96999ba)

## Notice
- 카카오 로그인 시 가입된 이메일이 없는 경우 에러메세지는 이미 있어서 추가로 구현하지 않았습니다.
