### PR TITLE
🔧 fix: 로그인하지 않아도 사진 작가 상세 조회 가능하도록 수정

### DIFF
--- a/snapspot-admin/src/main/java/snap/dto/MemberRes.java
+++ b/snapspot-admin/src/main/java/snap/dto/MemberRes.java
@@ -1,0 +1,16 @@
+package snap.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import snap.domains.member.entity.Member;
+
+@Getter
+@NoArgsConstructor
+public class MemberRes {
+
+	private Member member;
+
+	public MemberRes(Member member){
+		this.member = member;
+	}
+}

--- a/snapspot-admin/src/main/java/snap/service/JwtSecurityService.java
+++ b/snapspot-admin/src/main/java/snap/service/JwtSecurityService.java
@@ -4,14 +4,19 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import snap.domains.member.entity.Member;
+import snap.domains.member.service.MemberDomainService;
+import snap.dto.MemberRes;
 import snap.dto.TokenRes;
 import snap.enums.Role;
 import snap.jwt.JwtTokenUtil;
 
 import java.time.Duration;
+
+import javax.servlet.http.HttpServletRequest;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +25,7 @@ public class JwtSecurityService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final PasswordEncoder passwordEncoder;
     private final RedisService redisService;
+    private final MemberDomainService memberDomainService;
 
     public TokenRes createJwt(String email, String password) {
         UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(email, password);
@@ -56,5 +62,11 @@ public class JwtSecurityService {
 
     public String encryptPassword(String password) {
         return passwordEncoder.encode(password);
+    }
+
+    public MemberRes getMemberByRequest(HttpServletRequest request){
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        return new MemberRes(memberDomainService.findMemberByEmail(authentication.getName())
+            .orElseGet(() -> null));
     }
 }

--- a/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
+++ b/snapspot-api/src/main/java/snap/api/photographer/controller/PhotographerController.java
@@ -18,10 +18,12 @@ import snap.api.review.service.ReviewService;
 import snap.domains.member.entity.Member;
 import snap.domains.photographer.entity.Photographer;
 import snap.dto.request.PhotographerFilterReq;
-import snap.resolver.AuthMember;
 import snap.resolver.AuthPhotographer;
+import snap.service.JwtSecurityService;
 
 import java.util.List;
+
+import javax.servlet.http.HttpServletRequest;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,6 +33,7 @@ public class PhotographerController {
     private final PhotographerService photographerService;
     private final ReviewService reviewService;
     private final MemberService memberService;
+    private final JwtSecurityService jwtSecurityService;
 
     @GetMapping("/me")
     public ResponseEntity<PhotographerResponseDto> photographerInfoFind(@AuthPhotographer Photographer photographer) {
@@ -44,7 +47,8 @@ public class PhotographerController {
     }
 
     @GetMapping("/{photographerId}")
-    public ResponseEntity<PhotographerWithHeartDto> photographerFindById(@PathVariable Long photographerId, @AuthMember Member member) {
+    public ResponseEntity<PhotographerWithHeartDto> photographerFindById(@PathVariable Long photographerId, HttpServletRequest request) {
+        Member member = jwtSecurityService.getMemberByRequest(request).getMember();
         return new ResponseEntity<>(photographerService.findPhotographer(photographerId, member), HttpStatus.OK);
     }
 

--- a/snapspot-domain/src/main/java/snap/domains/heart/service/HeartDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/heart/service/HeartDomainService.java
@@ -40,6 +40,7 @@ public class HeartDomainService {
     }
 
     public Boolean existsHeart(Member member, Photographer photographer){
+        if (member == null) return false;
         return heartRepository.existsByMemberAndPhotographer(member, photographer);
     }
 }


### PR DESCRIPTION
기존의 사진 작가 상세 조회 코드는 @AuthMember를 사용하여 회원 정보를 받아오고, 이 회원이 사진 작가에게 좋아요를 눌렀는지 확인하는 로직으로 만들어졌기 때문에, 로그인하지 않은 상태에서 api를 요청하면 에러가 발생하였습니다. 

따라서 로그인하지 않은 상태에서도 사진 작가 상세 조회가 가능하도록 @AuthMember를 사용하지 않고, 새로운 메서드를 생성하였습니다.