### PR TITLE
✨ feat: BaseTimeEntity 추가, Plan 조회 시 최신순 정렬

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,6 @@ buildscript {
 	}
 }
 
-
 plugins {
 	id 'java'
 	id 'org.springframework.boot' version '2.7.13'

--- a/snapspot-api/src/main/java/snap/ApiApplication.java
+++ b/snapspot-api/src/main/java/snap/ApiApplication.java
@@ -3,11 +3,13 @@ package snap;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 import javax.annotation.PostConstruct;
 import java.util.TimeZone;
 
+@EnableJpaAuditing
 @EntityScan(basePackages = {"snap"})
 @EnableJpaRepositories(basePackages = {"snap"})
 @SpringBootApplication

--- a/snapspot-api/src/main/java/snap/api/message/dto/MessageResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/message/dto/MessageResponseDto.java
@@ -9,6 +9,8 @@ import snap.domains.message.entity.Message;
 import snap.domains.message.entity.Sender;
 import snap.enums.Role;
 
+import java.time.LocalDateTime;
+
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class MessageResponseDto {
@@ -16,6 +18,7 @@ public class MessageResponseDto {
     private Boolean isMine;
     private Sender sender;
     private String contents;
+    private LocalDateTime createdAt;
 
     public MessageResponseDto(Message message, Member member) {
         Sender sender = Sender.MEMBER;
@@ -27,5 +30,6 @@ public class MessageResponseDto {
         this.contents = message.getContents();
         this.sender = message.getSender();
         this.isMine = sender.equals(message.getSender());
+        this.createdAt = message.getCreatedAt();
     }
 }

--- a/snapspot-api/src/main/java/snap/api/message/service/MessageService.java
+++ b/snapspot-api/src/main/java/snap/api/message/service/MessageService.java
@@ -30,15 +30,12 @@ public class MessageService {
         }
         Plan plan = planDomainService.findByPlanId(request.getPlanId());
 
-
         if (!plan.getCustomer().getMemberId().equals(member.getMemberId()))
         {
             if (!plan.getPhotographer().getMember().getMemberId().equals(member.getMemberId())) {
                 throw new IllegalArgumentException("사진 촬영 일정에 대해 권한이 있는 일반 계정 혹은 사진작가 계정이 아닙니다.");
             }
         }
-
-
 
         return messageDomainService.createMessage(
                 plan,

--- a/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanFullResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanFullResponseDto.java
@@ -38,6 +38,8 @@ public class PlanFullResponseDto {
     private String y;
     private Status status;
     private List<MessageResponseDto> messages;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     @Builder
     public PlanFullResponseDto(Plan plan, Member member, List<Message> messageList) {
@@ -59,5 +61,7 @@ public class PlanFullResponseDto {
         this.messages = messageList.stream()
                 .map(message -> new MessageResponseDto(message, member))
                 .collect(Collectors.toList());
+        this.createdAt = plan.getCreatedAt();
+        this.modifiedAt = plan.getModifiedAt();
     }
 }

--- a/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanFullResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanFullResponseDto.java
@@ -34,6 +34,8 @@ public class PlanFullResponseDto {
     private Long price;
     private String placeName;
     private String placeAddress;
+    private String x;
+    private String y;
     private Status status;
     private List<MessageResponseDto> messages;
 
@@ -51,7 +53,8 @@ public class PlanFullResponseDto {
         this.price = plan.getPrice();
         this.placeName = plan.getPlaceName();
         this.placeAddress = plan.getPlaceAddress();
-        // this.message = plan.getMessage();
+        this.x = plan.getX();
+        this.y = plan.getY();
         this.status = plan.getStatus();
         this.messages = messageList.stream()
                 .map(message -> new MessageResponseDto(message, member))

--- a/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/plan/dto/response/PlanResponseDto.java
@@ -33,6 +33,8 @@ public class PlanResponseDto {
     private Long price;
     private String request;
     private Status status;
+    private LocalDateTime createdAt;
+    private LocalDateTime modifiedAt;
 
     @Builder
     public PlanResponseDto(Plan plan) {
@@ -47,5 +49,7 @@ public class PlanResponseDto {
         this.wishPlace = plan.getWishPlace();
         this.request = plan.getRequest();
         this.status = plan.getStatus();
+        this.createdAt = plan.getCreatedAt();
+        this.modifiedAt = plan.getModifiedAt();
     }
 }

--- a/snapspot-api/src/main/java/snap/api/review/service/ReviewService.java
+++ b/snapspot-api/src/main/java/snap/api/review/service/ReviewService.java
@@ -45,6 +45,7 @@ public class ReviewService {
         return reviewList.stream().map(ReviewResponseDto::new).collect(Collectors.toList());
     }
 
+    @Transactional(readOnly = true)
     public List<ReviewResponseDto> findReviewListByPhotographer(Photographer photographer) {
         return reviewDomainService.findReviewListByPhotographer(photographer)
                 .stream().map(ReviewResponseDto::new).collect(Collectors.toList());

--- a/snapspot-domain/src/main/java/snap/domains/global/entity/BaseTimeEntity.java
+++ b/snapspot-domain/src/main/java/snap/domains/global/entity/BaseTimeEntity.java
@@ -1,0 +1,22 @@
+package snap.domains.global.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+    @CreatedDate
+    @Column(updatable = false, columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(columnDefinition = "TIMESTAMP")
+    private LocalDateTime modifiedAt;
+}

--- a/snapspot-domain/src/main/java/snap/domains/message/entity/Message.java
+++ b/snapspot-domain/src/main/java/snap/domains/message/entity/Message.java
@@ -4,14 +4,16 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import snap.domains.global.entity.BaseTimeEntity;
 import snap.domains.plan.entity.Plan;
 
 import javax.persistence.*;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Message {
+public class Message extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long messageId;

--- a/snapspot-domain/src/main/java/snap/domains/plan/entity/Plan.java
+++ b/snapspot-domain/src/main/java/snap/domains/plan/entity/Plan.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.GenericGenerator;
 import org.hibernate.annotations.Type;
+import snap.domains.global.entity.BaseTimeEntity;
 import snap.domains.member.entity.Member;
 import snap.domains.photographer.entity.Photographer;
 import snap.domains.review.entity.Review;
@@ -21,7 +22,7 @@ import java.util.UUID;
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Plan {
+public class Plan extends BaseTimeEntity {
     @Id
     @GeneratedValue(generator = "uuid2")
     @GenericGenerator(name = "uuid2", strategy = "org.hibernate.id.UUIDGenerator")

--- a/snapspot-domain/src/main/java/snap/domains/plan/repository/PlanJPARepository.java
+++ b/snapspot-domain/src/main/java/snap/domains/plan/repository/PlanJPARepository.java
@@ -12,15 +12,14 @@ import java.util.UUID;
 
 public interface PlanJPARepository extends JpaRepository<Plan, UUID> {
 
-    List<Plan> findAllByCustomer(Member member);
-    List<Plan> findAllByPhotographer(Photographer photographer);
+    List<Plan> findAllByCustomerOrderByCreatedAtDesc(Member member);
+    List<Plan> findAllByPhotographerOrderByCreatedAtDesc(Photographer photographer);
 
     List<Plan> findAllByPhotographerAndStatus(Photographer photographer, Status status1);
 
-    List<Plan> findAllByPhotographerAndStatusOrStatus(Photographer photographer, Status status1, Status status2);
+    List<Plan> findAllByPhotographerAndStatusOrStatusOrderByCreatedAtDesc(Photographer photographer, Status status1, Status status2);
+    List<Plan> findAllByPhotographerAndStatusOrStatusOrStatusOrderByCreatedAtDesc(Photographer photographer, Status status1, Status status2, Status status3);
 
-    List<Plan> findAllByPhotographerAndStatusOrStatusOrStatus(Photographer photographer, Status status1, Status status2, Status status3);
-    
     Optional<Plan> findByPlanIdAndCustomer(UUID planId, Member member);
 
 }

--- a/snapspot-domain/src/main/java/snap/domains/plan/repository/PlanQueryDslRepository.java
+++ b/snapspot-domain/src/main/java/snap/domains/plan/repository/PlanQueryDslRepository.java
@@ -21,7 +21,6 @@ public class PlanQueryDslRepository {
     private final EntityManager em;
     private final JPAQueryFactory queryFactory;
 
-
     public void changePlanStatusOfToday() {
         LocalDateTime now = LocalDateTime.now();
         now = LocalDateTime.of(now.getYear(), now.getMonth(), now.getDayOfMonth(), 0, 0, 0);

--- a/snapspot-domain/src/main/java/snap/domains/plan/service/PlanDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/plan/service/PlanDomainService.java
@@ -78,12 +78,12 @@ public class PlanDomainService {
 
     @Transactional(readOnly = true)
     public List<Plan> findByPhotographer(Photographer photographer) {
-        return planRepository.findAllByPhotographer(photographer);
+        return planRepository.findAllByPhotographerOrderByCreatedAtDesc(photographer);
     }
 
     @Transactional(readOnly = true)
     public List<Plan> findByMember(Member member) {
-        return planRepository.findAllByCustomer(member);
+        return planRepository.findAllByCustomerOrderByCreatedAtDesc(member);
     }
 
     public Plan findByPlanIdAndMember(UUID planId, Member member) {
@@ -100,12 +100,12 @@ public class PlanDomainService {
 
     @Transactional(readOnly = true)
     public List<Plan> findByPhotographerAndStatus1(Photographer photographer, Status status, Status status1) {
-        return planRepository.findAllByPhotographerAndStatusOrStatus(photographer, status, status1);
+        return planRepository.findAllByPhotographerAndStatusOrStatusOrderByCreatedAtDesc(photographer, status, status1);
     }
 
     @Transactional(readOnly = true)
     public List<Plan> findByPhotographerAndStatus(Photographer photographer, Status status, Status status1, Status status2) {
-        return planRepository.findAllByPhotographerAndStatusOrStatusOrStatus(photographer,status,status1,status2);
+        return planRepository.findAllByPhotographerAndStatusOrStatusOrStatusOrderByCreatedAtDesc(photographer,status,status1,status2);
     }
 
     public void changePlan(


### PR DESCRIPTION
## Details
- BaseTimeEntity 추가
- Message 생성 시 전송 시간 추가
- Message 조회 시 전송 시간 추가
- Plan 생성/변경 시 생성/변경 시간 추가
- Plan 조회 시 생성/변경 시간 추가
- Plan 조회 시 생성 시간 최신순으로 정렬

## Test 사항
- Message가 생성될 때 생성 시간이 저장되는지
- Plan이 생성될 때 생성 시간이 저장되는지
- Plan이 변경될 때 변경 시간이 저장되는지
- Message 조회 시 생성 시간도 조회되는지
- Plan 조회 시 생성 시간과 변경 시간도 조회되는지
- Plan에서 @GetMapping("/member"), @GetMapping("/photographer"), @GetMapping("/photographer/client") 조회 시 Plan이 생성 시간 최신순으로 정렬되는지
