### PR TITLE
✨ feat: 예약 과정에서 전송되는 메세지 커스텀

### DIFF
--- a/snapspot-api/src/main/java/snap/api/message/dto/MessageResponseDto.java
+++ b/snapspot-api/src/main/java/snap/api/message/dto/MessageResponseDto.java
@@ -17,6 +17,7 @@ public class MessageResponseDto {
     private Long messageId;
     private Boolean isMine;
     private Sender sender;
+    private String custom;
     private String contents;
     private LocalDateTime createdAt;
 
@@ -27,6 +28,7 @@ public class MessageResponseDto {
         }
 
         this.messageId = message.getMessageId();
+        this.custom = message.getCustom();
         this.contents = message.getContents();
         this.sender = message.getSender();
         this.isMine = sender.equals(message.getSender());

--- a/snapspot-api/src/main/java/snap/api/plan/service/PlanService.java
+++ b/snapspot-api/src/main/java/snap/api/plan/service/PlanService.java
@@ -53,7 +53,7 @@ public class PlanService {
     public PlanFullResponseDto refusePlan(Member member, RefuseRequestDto requestDto) {
         Plan plan = planDomainService.findByPlanId(requestDto.getPlanId());
         Plan updatedPlan = planDomainService.updateState(plan, Status.REFUSE);
-        Message message = messageDomainService.createMessage(updatedPlan, requestDto.getContents(), Sender.PHOTOGRAPHER);
+        Message message = messageDomainService.createCustomMessage(updatedPlan, "거절 사유", requestDto.getContents(), Sender.PHOTOGRAPHER);
         return new PlanFullResponseDto(plan, member, messageDomainService.findByPlanId(plan.getPlanId()));
     }
 
@@ -70,7 +70,7 @@ public class PlanService {
     public void reservePlan(PlanReservedDto requestDto) {
         Plan plan = planDomainService.findByPlanId(requestDto.getPlanId());
         Plan updatedPlan = planDomainService.updateState(plan, Status.RESERVED);
-        Message message = messageDomainService.createMessage(updatedPlan,requestDto.getContents(), Sender.PHOTOGRAPHER);
+        Message message = messageDomainService.createCustomMessage(updatedPlan, "예약 완료", requestDto.getContents(), Sender.PHOTOGRAPHER);
     }
 
     public void cancelPlan(Member member, PlanCancelDto requestDto) {
@@ -82,7 +82,7 @@ public class PlanService {
             sender = Sender.PHOTOGRAPHER;
         }
 
-        Message message = messageDomainService.createMessage(updatedPlan, "취소되었습니다.", sender);
+        Message message = messageDomainService.createCustomMessage(updatedPlan, "취소 사유", "취소되었습니다.", sender);
     }
 
     public void completePlan(MultipartFile file, PlanCompleteDto requestDto) {

--- a/snapspot-domain/src/main/java/snap/domains/message/entity/Message.java
+++ b/snapspot-domain/src/main/java/snap/domains/message/entity/Message.java
@@ -23,6 +23,9 @@ public class Message extends BaseTimeEntity {
     private Plan plan;
 
     @Column
+    private String custom;
+
+    @Column
     private String contents;
 
     @Column
@@ -30,8 +33,9 @@ public class Message extends BaseTimeEntity {
     private Sender sender;
 
     @Builder
-    public Message(Plan plan, String contents, Sender sender) {
+    public Message(Plan plan, String custom, String contents, Sender sender) {
         this.plan = plan;
+        this.custom = custom;
         this.contents = contents;
         this.sender = sender;
     }

--- a/snapspot-domain/src/main/java/snap/domains/message/service/MessageDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/message/service/MessageDomainService.java
@@ -26,6 +26,15 @@ public class MessageDomainService {
                 .build());
     }
 
+    public Message createCustomMessage(Plan plan, String custom, String contents, Sender sender) {
+        return messageRepository.save(Message.builder()
+                .plan(plan)
+                .custom(custom)
+                .contents(contents)
+                .sender(sender)
+                .build());
+    }
+
     public List<Message> findByPlanId(UUID planId) {
         return messageRepository.findAllByPlan_PlanId(planId);
     }

--- a/snapspot-domain/src/main/java/snap/domains/plan/service/PlanDomainService.java
+++ b/snapspot-domain/src/main/java/snap/domains/plan/service/PlanDomainService.java
@@ -58,6 +58,7 @@ public class PlanDomainService {
 
         messageRepository.save(Message.builder()
                         .plan(requestedPlan)
+                        .custom("입금 요청")
                         .contents(plan.getMessage())
                         .sender(Sender.PHOTOGRAPHER)
                 .build());
@@ -123,6 +124,7 @@ public class PlanDomainService {
         );
         messageRepository.save(Message.builder()
                 .plan(plan)
+                .custom("변경 사유")
                 .contents(message)
                 .sender(Sender.MEMBER)
                 .build());


### PR DESCRIPTION
## Details
- 예약 과정에서 메세지를 전송할 때 어떤 메세지인지 표시하도록 커스텀했습니다.
- 예약 과정에서 전송되는 메세지는 단계에 따라 다음과 같은 커스텀 문구가 같이 저장됩니다.
  - deposit: 입금 요청
  - refuse: 거절 사유
  - reserved: 예약 완료
  - cancel: 취소 사유
  - change: 변경 사유
---
- 메세지 커스텀 잘 구현되었는지 테스트를 못 해서 확인 부탁드립니다!
- PlanService의 cancelPlan에서 PlanCancelDto의 refundAccount 값이 작가에게 잘 전달되고 있는지 코드 확인 부탁드려요!